### PR TITLE
fix: Improve data point selection and editing in theme editor

### DIFF
--- a/src/SSRS.Brand.Editor.Application/ViewModels/ThemeColorsViewModel.cs
+++ b/src/SSRS.Brand.Editor.Application/ViewModels/ThemeColorsViewModel.cs
@@ -41,7 +41,13 @@ public sealed class ThemeColorsViewModel(ThemeColorsModel model) : ViewModelBase
 	public Color SelectedDataPoint
 	{
 		get => _selectedDataPoint;
-		set => SetProperty(ref _selectedDataPoint, value);
+		set
+		{
+			SetProperty(ref _selectedDataPoint, value);
+
+			if (_selectedDataPointIndex >= 0 && _selectedDataPointIndex < model.DataPoints.Count)
+				model.DataPoints[_selectedDataPointIndex] = value;
+		}
 	}
 
 	/// <summary>
@@ -50,7 +56,17 @@ public sealed class ThemeColorsViewModel(ThemeColorsModel model) : ViewModelBase
 	public int SelectedDataPointIndex
 	{
 		get => _selectedDataPointIndex;
-		set => SetProperty(ref _selectedDataPointIndex, value);
+		set
+		{
+			SetProperty(ref _selectedDataPointIndex, value);
+			_removeDataPointCommand?.RaiseCanExecuteChanged();
+
+			if (value >= 0 && value < model.DataPoints.Count)
+			{
+				_selectedDataPoint = model.DataPoints[value];
+				RaisePropertyChanged(nameof(SelectedDataPoint));
+			}
+		}
 	}
 
 	/// <summary>

--- a/src/SSRS.Brand.Editor.Presentation/Controls/ThemeColorsEditorControl.xaml
+++ b/src/SSRS.Brand.Editor.Presentation/Controls/ThemeColorsEditorControl.xaml
@@ -12,6 +12,7 @@
 						 d:Width="380">
 	<UserControl.Resources>
 		<conv:DrawingColorToBrushConverter x:Key="ColorToBrush" />
+		<conv:IndexToVisibilityConverter x:Key="IndexToVisibility" />
 		<Style x:Key="SwatchRect"
 					 TargetType="Rectangle">
 			<Setter Property="Width"
@@ -60,8 +61,11 @@
 							<Run Text=" data point(s)" />
 						</TextBlock>
 					</DockPanel>
-					<ItemsControl ItemsSource="{Binding DataPoints}">
-						<ItemsControl.ItemTemplate>
+					<ListBox ItemsSource="{Binding DataPoints}"
+									 SelectedIndex="{Binding SelectedDataPointIndex}"
+									 HorizontalContentAlignment="Stretch"
+									 Margin="0,0,0,8">
+						<ListBox.ItemTemplate>
 							<DataTemplate>
 								<DockPanel Margin="2">
 									<Rectangle Style="{StaticResource SwatchRect}"
@@ -71,8 +75,11 @@
 														 Text="{Binding Converter={StaticResource ColorToBrush}, StringFormat={}{0}}" />
 								</DockPanel>
 							</DataTemplate>
-						</ItemsControl.ItemTemplate>
-					</ItemsControl>
+						</ListBox.ItemTemplate>
+					</ListBox>
+					<local:ColorSwatchControl Label="Selected Data Point"
+																		Color="{Binding SelectedDataPoint}"
+																		Visibility="{Binding SelectedDataPointIndex, Converter={StaticResource IndexToVisibility}}" />
 				</StackPanel>
 			</Expander>
 

--- a/src/SSRS.Brand.Editor.Presentation/Converters/IndexToVisibilityConverter.cs
+++ b/src/SSRS.Brand.Editor.Presentation/Converters/IndexToVisibilityConverter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright: 2025 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace SSRS.Brand.Editor.Presentation.Converters;
+
+/// <summary>
+/// Converts an integer index to <see cref="Visibility"/>.
+/// Returns <see cref="Visibility.Visible"/> when the index is non-negative,
+/// otherwise <see cref="Visibility.Collapsed"/>.
+/// </summary>
+[ValueConversion(typeof(int), typeof(Visibility))]
+public sealed class IndexToVisibilityConverter : IValueConverter
+{
+	/// <inheritdoc/>
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		=> value is int index && index >= 0 ? Visibility.Visible : Visibility.Collapsed;
+
+	/// <inheritdoc/>
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		=> throw new NotSupportedException();
+}


### PR DESCRIPTION
- Replace ItemsControl with ListBox for data point selection and bind SelectedDataPointIndex for two-way selection.
- Update ViewModel to sync SelectedDataPoint and DataPoints collection.
- Show ColorSwatchControl only when a data point is selected, using new IndexToVisibilityConverter.
- Add IndexToVisibilityConverter for conditional UI visibility.
- Enhances user experience and data binding consistency for editing data point colors.

closes #184